### PR TITLE
Add Laravel integration and API key rotation support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## v5.0.4 - 2025-08-31
+- Add optional Laravel integration in-core: Service Provider, Facade, Manager, and Http adapter.
+- Explicit instance creation model in Laravel: `Tron::make(...)/app('tron')->make(...)` always returns a fresh instance (no hidden singletons).
+- Core factory: `Tron::init([...])` with network presets (mainnet, shasta, nile), custom endpoints, headers, `api_key`, and `auth` options.
+- API key rotation (Laravel only): round-robin across keys from `TRON_API_KEY` (comma-separated) or `api_keys` array; persists last index in Cache; per-instance override via `['api_key' => '...']`.
+- HTTP semantics: do not send a body with GET requests; only set Guzzle `auth` when credentials are provided.
+- Documentation: revamped README (features, usage, Laravel config, key rotation) for clarity and predictability.
+- Composer: add Laravel auto-discovery entries; add `illuminate/cache` to `suggest` for rotation persistence.
+
+## v5.0.3 - 2025-08-31
+- Compatibility: PSR-7 v2 friendly by switching `web3p/web3.php` to `^0.1.6` (removes `react/http` coupling).
+- Tooling & docs: badges, CI/release workflows, CHANGELOG; README updates for install/requirements/usage.
+
 ## v5.0.2 - 2025-08-31
 - Fix Laravel 12 install conflict by switching `web3p/web3.php` to `^0.1.6` (removes `react/http` → no PSR-7 v1 lock).
 - Remove abandoned `comely-io/data-types`; replace internal usage with `bcmath`.
@@ -13,4 +26,3 @@ All notable changes to this project will be documented in this file.
 
 ## v5.0.1 - 2025-08-30
 - Initial 5.x fork release under `sultanov-solutions` vendor.
-

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,21 @@
     "config": {
         "sort-packages": true
     },
+    "suggest": {
+        "illuminate/support": "^12.0 for Laravel integration (provider, manager)",
+        "illuminate/http": "^12.0 for Laravel Http client adapter",
+        "illuminate/cache": "^12.0 for API key rotation persistence"
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "IEXBase\\TronAPI\\Laravel\\TronServiceProvider"
+            ],
+            "aliases": {
+                "Tron": "IEXBase\\TronAPI\\Laravel\\Facades\\Tron"
+            }
+        }
+    },
 
     "prefer-stable": true
 }

--- a/config/tron.php
+++ b/config/tron.php
@@ -1,0 +1,58 @@
+<?php
+
+return [
+    'default' => env('TRON_DEFAULT', 'mainnet'),
+
+    'connections' => [
+        'mainnet' => [
+            'network' => 'mainnet',
+            'endpoints' => [
+                'full_node' => env('TRON_FULLNODE', 'https://api.trongrid.io'),
+                'solidity_node' => env('TRON_SOLIDITY_NODE', 'https://api.trongrid.io'),
+                'event_server' => env('TRON_EVENT_SERVER', 'https://api.trongrid.io'),
+                'status_page' => '/',
+            ],
+            'timeout_ms' => env('TRON_TIMEOUT_MS', 30000),
+            'headers' => [],
+            // API key(s) for TronGrid/Tronscan.
+            // You can set TRON_API_KEY as comma-separated list to enable rotation.
+            // Example: TRON_API_KEY=key1,key2,key3
+            'api_key' => env('TRON_API_KEY'), // string or comma-separated list; overrides api_keys
+            // 'api_keys' => ['key1','key2','key3'], // explicit list alternative
+            'auth' => [
+                // 'basic' => [env('TRON_BASIC_USER'), env('TRON_BASIC_PASS')],
+                // 'bearer' => env('TRON_BEARER_TOKEN'),
+            ],
+            // 'private_key' => env('TRON_PRIVATE_KEY'),
+            // 'address' => env('TRON_ADDRESS'),
+        ],
+
+        'shasta' => [
+            'network' => 'shasta',
+            'endpoints' => [
+                'full_node' => 'https://api.shasta.trongrid.io',
+                'solidity_node' => 'https://api.shasta.trongrid.io',
+                'event_server' => 'https://api.shasta.trongrid.io',
+                'status_page' => '/',
+            ],
+            'timeout_ms' => env('TRON_TIMEOUT_MS', 30000),
+            'headers' => [],
+            'api_key' => env('TRON_API_KEY'),
+            'auth' => [],
+        ],
+
+        'nile' => [
+            'network' => 'nile',
+            'endpoints' => [
+                'full_node' => 'https://nile.trongrid.io',
+                'solidity_node' => 'https://nile.trongrid.io',
+                'event_server' => 'https://nile.trongrid.io',
+                'status_page' => '/',
+            ],
+            'timeout_ms' => env('TRON_TIMEOUT_MS', 30000),
+            'headers' => [],
+            'api_key' => env('TRON_API_KEY'),
+            'auth' => [],
+        ],
+    ],
+];

--- a/docs/LARAVEL_BRIDGE_SPEC.md
+++ b/docs/LARAVEL_BRIDGE_SPEC.md
@@ -1,0 +1,139 @@
+# Laravel Bridge Specification (sultanov-solutions/laravel-tron-api)
+
+This document describes how to build a Laravel integration package for the core library `sultanov-solutions/tron-api` without coupling the core to Laravel. Copy this into a new repository as the blueprint for the bridge.
+
+## Package Scope
+- Name: `sultanov-solutions/laravel-tron-api`
+- Purpose: First‑class Laravel 12 integration (DI bindings, config, Http client adapter, optional caching/retries/logging), while keeping the core library framework‑agnostic.
+- Core dependency: `sultanov-solutions/tron-api` (this repo)
+
+## Composer
+- require:
+  - `php`: `^8.1`
+  - `illuminate/support`: `^12.0`
+  - `illuminate/http`: `^12.0`
+  - `sultanov-solutions/tron-api`: `^5.0`
+- autoload (PSR‑4):
+  - `SultanovSolutions\\LaravelTronAPI\\` → `src/`
+- extra.laravel (auto‑discovery):
+  - providers:
+    - `SultanovSolutions\\LaravelTronAPI\\TronServiceProvider`
+  - aliases (optional, if providing a facade):
+    - `"Tron": "SultanovSolutions\\\\LaravelTronAPI\\\\Facades\\\\Tron"`
+
+## Public Surface (Bridge)
+- Service Provider: `TronServiceProvider`
+  - Publishes config file `config/tron.php`
+  - Binds interfaces and singletons in the container
+  - Optionally wires a PSR‑3 logger if core exposes one
+- Facade (optional): `SultanovSolutions\\LaravelTronAPI\\Facades\\Tron`
+  - Resolves the core `IEXBase\\TronAPI\\Tron` singleton from the container
+- Console command(s) (optional):
+  - `tron:ping` — checks node health and prints basic info
+
+## Container Bindings
+- Bind core HTTP abstraction to a Laravel adapter:
+  - `IEXBase\\TronAPI\\Provider\\HttpProviderInterface` → `SultanovSolutions\\LaravelTronAPI\\Http\\LaravelHttpProvider`
+- Register a singleton of the core `IEXBase\\TronAPI\\Tron` configured from `config/tron.php`:
+  - Construct `HttpProvider` instances for `fullNode`, `solidityNode`, `eventServer`
+  - Support optional `signServer` and `explorer` if needed
+  - Optionally set a private key if present in config/env (use with care)
+
+## HTTP Adapter Responsibilities
+- Class: `SultanovSolutions\\LaravelTronAPI\\Http\\LaravelHttpProvider`
+- Implements core `HttpProviderInterface`
+- Uses `Illuminate\\Http\\Client\\Factory` (or `Http` facade) under the hood
+- Base URL: `baseUrl($host)`
+- Headers: `withHeaders([...])` from config
+- Timeout: `timeout($timeoutMs / 1000)`
+- Retries (optional): `retry($times, $sleepMs)` (configurable)
+- GET semantics: do NOT send a request body; use query where applicable
+- POST semantics: send JSON body
+- Response mapping:
+  - Decode JSON to array; if body is literal `OK`, return `['status' => 1]`
+  - 404 → throw core `NotFoundException`
+  - Non‑2xx → throw core `TronException` with a helpful message
+- Optional caching layer for idempotent GETs via `Cache` (TTL from config)
+- Do not log secrets; mask bearer tokens in logs/events
+
+## Config (`config/tron.php`)
+Recommended keys (with sensible defaults):
+- `full_node` (string): default `https://api.trongrid.io`
+- `solidity_node` (string): default `https://api.trongrid.io`
+- `event_server` (string): default `https://api.trongrid.io`
+- `status_page` (string): default `/` (used by isConnected)
+- `timeout_ms` (int): default `30000`
+- `retries` (array): `{ 'times' => 2, 'sleep_ms' => 200 }`
+- `headers` (array): default `[]`
+- `auth` (array): `{ 'basic' => null, 'bearer' => null }`
+- `cache` (array): `{ 'enabled' => false, 'ttl' => 5 }` // only for safe GETs
+- `log_channel` (string|null): default `null` // if set, adapter uses this channel
+- `private_key` (string|null): default `null` // optional; use with caution
+- Environment variables to support:
+  - `TRON_FULLNODE`, `TRON_SOLIDITY_NODE`, `TRON_EVENT_SERVER`
+  - `TRON_TIMEOUT_MS`, `TRON_RETRIES`, `TRON_HEADERS_JSON`
+  - `TRON_BASIC_USER`, `TRON_BASIC_PASS`, `TRON_BEARER_TOKEN`
+
+## Events & Logging (Optional)
+- Consider dispatching Laravel events for observability:
+  - `TronRequestDispatched` (method, url, payload, headers, trace id)
+  - `TronResponseReceived` (status, duration, body size, trace id)
+- If `log_channel` configured, log request/response meta (mask secrets)
+- Integrate with Telescope automatically if available (optional)
+
+## Testing
+- Use `orchestra/testbench` to boot a minimal Laravel app for package tests
+- Test cases:
+  - Config publishing works and defaults load
+  - Container resolves `Tron` and `HttpProviderInterface` bindings
+  - Adapter maps GET/POST correctly (no body for GET)
+  - Retry/timeout behavior from config is applied
+  - 404 throws core `NotFoundException`; non‑2xx throws `TronException`
+  - Optional cache behavior for GETs respects TTL and toggle
+
+## CI
+- GitHub Actions matrix:
+  - OS: ubuntu‑latest
+  - PHP: 8.1, 8.2, 8.3
+  - Laravel: 12.* (via `illuminate/*` constraints)
+- Steps:
+  - `composer validate`
+  - `composer install`
+  - `vendor/bin/phpunit`
+
+## Documentation (README template)
+Include:
+- What this package does (Laravel adapter for `sultanov-solutions/tron-api`)
+- Requirements (PHP 8.1+, Laravel 12)
+- Install:
+  - `composer require sultanov-solutions/laravel-tron-api`
+  - publish config: `php artisan vendor:publish --tag=tron-config`
+- Quick start:
+  - `Tron::getBalance()` via facade or `app(Tron::class)`
+- Configuration keys and env variables
+- Notes on retries, timeouts, caching, logging
+- Credits: link to core and upstream `iexbase/tron-api`
+- Donations (both upstream and maintainer)
+- Badges: CI, Packagist version/downloads, PHP, Laravel
+
+## SemVer & Releases
+- Follow SemVer; keep bridge’s major version aligned with core’s major where possible
+- Tag releases as `vX.Y.Z`; do not retag existing versions
+- Enable Packagist auto‑updates via GitHub App or webhook
+
+## Security
+- Do not log private keys, bearer tokens, or raw payloads
+- Mask secrets in events/logs; opt‑in verbose logging only in non‑prod
+
+## Non‑Goals
+- The bridge must not re‑implement business logic from the core library
+- No breaking changes to the core’s public API; only adaptation to Laravel
+
+## Nice‑to‑Have (Future)
+- Health endpoint diagnostics command (`tron:health`)
+- Middleware for injecting correlation IDs into requests
+- Rate‑limit/backoff policies configurable per method
+
+---
+
+By keeping the core clean and shipping Laravel glue here, Laravel users get a first‑class experience (Http facade, config, DI, retries, logging, caching) with zero impact on non‑Laravel consumers.

--- a/src/Laravel/Facades/Tron.php
+++ b/src/Laravel/Facades/Tron.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IEXBase\TronAPI\Laravel\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @method static \IEXBase\TronAPI\Tron make(string $name = null, array $override = []) Create a fresh Tron instance for the given connection and options
+ */
+class Tron extends Facade
+{
+    protected static function getFacadeAccessor()
+    {
+        return 'tron';
+    }
+}

--- a/src/Laravel/Http/LaravelHttpProvider.php
+++ b/src/Laravel/Http/LaravelHttpProvider.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IEXBase\TronAPI\Laravel\Http;
+
+use IEXBase\TronAPI\Exception\NotFoundException;
+use IEXBase\TronAPI\Exception\TronException;
+use IEXBase\TronAPI\Provider\HttpProviderInterface;
+use Illuminate\Support\Facades\Http;
+
+class LaravelHttpProvider implements HttpProviderInterface
+{
+    protected string $host;
+    protected int $timeout;
+    protected array $headers;
+    protected string $statusPage = '/';
+
+    public function __construct(string $host, int $timeout = 30000, array $headers = [], string $statusPage = '/')
+    {
+        $this->host = $host;
+        $this->timeout = $timeout;
+        $this->headers = $headers;
+        $this->statusPage = $statusPage;
+    }
+
+    public function setStatusPage(string $page = '/'): void
+    {
+        $this->statusPage = $page;
+    }
+
+    public function isConnected(): bool
+    {
+        $resp = $this->request($this->statusPage);
+        return isset($resp['blockID']) || isset($resp['status']);
+    }
+
+    public function request($url, array $payload = [], string $method = 'get'): array
+    {
+        $method = strtoupper($method);
+        if (!in_array($method, ['GET','POST'])) {
+            throw new TronException('The method is not defined');
+        }
+
+        $client = Http::baseUrl($this->host)
+            ->withHeaders($this->headers)
+            ->timeout(max(1, (int)ceil($this->timeout / 1000)));
+
+        try {
+            if ($method === 'GET') {
+                $response = $client->get($url, $payload);
+            } else {
+                $response = $client->asJson()->post($url, $payload);
+            }
+        } catch (\Throwable $e) {
+            throw new TronException($e->getMessage(), $e->getCode(), $e);
+        }
+
+        if ($response->status() === 404) {
+            throw new NotFoundException('Page not found');
+        }
+
+        $body = $response->body();
+        if ($body === 'OK') {
+            return ['status' => 1];
+        }
+
+        $decoded = json_decode($body, true);
+        if (!is_array($decoded)) {
+            $decoded = [];
+        }
+
+        return $decoded;
+    }
+}
+

--- a/src/Laravel/TronManager.php
+++ b/src/Laravel/TronManager.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IEXBase\TronAPI\Laravel;
+
+use IEXBase\TronAPI\Tron;
+use IEXBase\TronAPI\Laravel\Http\LaravelHttpProvider;
+use Illuminate\Support\Manager;
+use Illuminate\Support\Facades\Cache;
+
+class TronManager extends Manager
+{
+    public function getDefaultDriver()
+    {
+        return $this->app['config']['tron.default'] ?? 'mainnet';
+    }
+
+    /**
+     * Create connection by name from config/tron.php
+     * Supports rotating API keys when multiple keys are provided in config/env.
+     * You can override rotation by passing explicit 'api_key' via make($name, ['api_key' => '...']).
+     */
+    public function createDriver($name)
+    {
+        return $this->make($name);
+    }
+
+    /**
+     * Build a fresh Tron instance with optional overrides.
+     * Example: app(TronManager::class)->make('mainnet', ['api_key' => 'HARDCODED']);
+     */
+    public function make($name = null, array $override = [])
+    {
+        $name = $name ?? $this->getDefaultDriver();
+        $connections = $this->app['config']['tron.connections'] ?? [];
+        $opts = $connections[$name] ?? [];
+
+        // Prepare API key with rotation (if not overridden)
+        $apiKey = $override['api_key'] ?? null;
+        if ($apiKey === null) {
+            $apiKey = $this->resolveApiKey($name, $opts);
+        }
+
+        $headers = $opts['headers'] ?? [];
+        if (!empty($apiKey)) {
+            $headers['TRON-PRO-API-KEY'] = $apiKey;
+        }
+
+        $timeout = (int)($opts['timeout_ms'] ?? 30000);
+        $factory = function($host, $timeoutMs, $headersArg, $status) {
+            return new LaravelHttpProvider($host, $timeoutMs, $headersArg, $status);
+        };
+
+        return Tron::init([
+            'network' => $override['network'] ?? ($opts['network'] ?? 'mainnet'),
+            'endpoints' => $override['endpoints'] ?? ($opts['endpoints'] ?? []),
+            'timeout_ms' => $override['timeout_ms'] ?? $timeout,
+            'headers' => $override['headers'] ?? $headers,
+            'auth' => $override['auth'] ?? ($opts['auth'] ?? []),
+            'private_key' => $override['private_key'] ?? ($opts['private_key'] ?? null),
+            'address' => $override['address'] ?? ($opts['address'] ?? null),
+            'http_provider_factory' => $override['http_provider_factory'] ?? $factory,
+            'api_key' => $apiKey, // still set to ensure headers in core path
+        ]);
+    }
+
+    protected function resolveApiKey(string $connectionName, array $opts): ?string
+    {
+        // Support comma-separated env TRON_API_KEY, explicit array api_keys, or single api_key
+        $keys = [];
+        if (!empty($opts['api_keys']) && is_array($opts['api_keys'])) {
+            $keys = array_values(array_filter(array_map('trim', $opts['api_keys']), fn($v)=>$v!==''));
+        } elseif (!empty($opts['api_key']) && is_string($opts['api_key'])) {
+            $parts = array_map('trim', explode(',', $opts['api_key']));
+            $keys = array_values(array_filter($parts, fn($v)=>$v!==''));
+        }
+
+        if (count($keys) <= 1) {
+            return $keys[0] ?? null;
+        }
+
+        $cacheKey = 'tron_api_key_index_'.$connectionName;
+        $index = Cache::get($cacheKey, -1);
+        $index = is_numeric($index) ? (int)$index : -1;
+        $next = ($index + 1) % count($keys);
+        Cache::forever($cacheKey, $next);
+        Cache::forever($cacheKey.':value', $keys[$next]);
+        return $keys[$next];
+    }
+}

--- a/src/Laravel/TronServiceProvider.php
+++ b/src/Laravel/TronServiceProvider.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IEXBase\TronAPI\Laravel;
+
+use Illuminate\Support\ServiceProvider;
+use IEXBase\TronAPI\Tron;
+
+class TronServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->mergeConfigFrom(__DIR__.'/../../config/tron.php', 'tron');
+
+        // Manager binding
+        $this->app->singleton(TronManager::class, function($app){
+            return new TronManager($app);
+        });
+
+        // Expose manager as 'tron' so usage is explicit: app('tron')->make([...])
+        $this->app->singleton('tron', function($app){
+            return $app->make(TronManager::class);
+        });
+    }
+
+    public function boot(): void
+    {
+        // Publish config
+        $this->publishes([
+            __DIR__.'/../../config/tron.php' => config_path('tron.php'),
+        ], 'tron-config');
+    }
+}


### PR DESCRIPTION
Introduces first-class Laravel integration with ServiceProvider, Facade, Manager, and a Laravel Http adapter. Adds config/tron.php for connection management, supports API key rotation (round-robin, persisted in Cache), and allows explicit instance creation via Tron::make/app('tron')->make. Refactors core to provide a static Tron::init factory with network presets and flexible options. Updates documentation and composer.json for Laravel auto-discovery and suggestions.