### PR TITLE
Remove version field from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
             "email": "info@sultanov-solutions.com"
         }
     ],
-    "version": "dev-main",
     "keywords": [
         "iexbase",
         "tron-lib",


### PR DESCRIPTION
The 'version' field was removed from composer.json, likely to allow Composer to manage the version automatically based on VCS tags.